### PR TITLE
fix: LVGL kb port, keycode ASCII hex mapping issue

### DIFF
--- a/Code/picocalc_lvgl_graphics_demo/README.md
+++ b/Code/picocalc_lvgl_graphics_demo/README.md
@@ -10,9 +10,8 @@ This repository provides a template demo application utilizing the LVGL graphics
 - [x] Ported I2C keyboard functionality for LVGL.
 - [x] Implemented SPI display support for LVGL.
 - [x] Enabled bitmap driver flushing.
+- [x] Enhanced keyboard event processing.
 
-#### Todos
-- [ ] eEnhance keyboard event processing.
 
 ## Build Instructions
 ```bash

--- a/Code/picocalc_lvgl_graphics_demo/lv_port_indev_picocalc_kb.c
+++ b/Code/picocalc_lvgl_graphics_demo/lv_port_indev_picocalc_kb.c
@@ -112,18 +112,119 @@ static void keypad_read(lv_indev_t * indev_drv, lv_indev_data_t * data)
     /*Get whether the a key is pressed and save the pressed key*/
     int r = keypad_get_key();
     
+    uint32_t act_key = 0;
     if (r > 0) {
         printf("Key event %x\n", r);
-        
-        uint32_t act_key = 0;
-        /*Translate the keys to LVGL control characters according to your key definitions*/
-        switch(r) {
-            case 0xb5:
+
+
+        /* Translate the keys to LVGL control characters according to your key definitions */
+        switch (r) {
+            case 0xb5: // Arrow Up
                 act_key = LV_KEY_NEXT;
                 break;
-            case 0xb6:
+            case 0xb6: // Arrow Down
                 act_key = LV_KEY_PREV;
                 break;
+            case 0xb4: // Arrow Left
+            case 0xb7: // Arrow Right
+                printf("WARN: ARROW Left/Right key not mapped\n");
+                act_key = 0;
+                break;
+
+            // Special Keys
+            // Row 1
+            case 0x81: case 0x82: case 0x83: case 0x84: case 0x85:
+            case 0x86: case 0x87: case 0x88: case 0x89: case 0x90:// F1-F10 Keys
+                printf("WARN: Function keys not mapped\n");
+                act_key = 0;
+                break;
+
+            // Row 2
+            case 0xB1: // ESC
+                act_key = LV_KEY_ESC;
+                break;
+            case 0x09: // TAB
+                printf("WARN: Tab key not mapped\n");
+                act_key = 0;
+                break;
+            case 0xC1: // Caps Lock
+                printf("WARN: CapLock key not mapped\n");
+                act_key = 0;
+                break;
+            case 0xD4: // DEL
+                act_key = LV_KEY_DEL;
+                break;
+            case 0x08: // Backspace
+                act_key = LV_KEY_BACKSPACE;
+                break;
+
+            // Row 2 Layer2
+            case 0xD0: // brk
+                printf("WARN: Brk key not mapped\n");
+                act_key = 0;
+                break;
+            case 0xD2: // Home
+                act_key = LV_KEY_HOME;
+                break;
+            case 0xD5: // End
+                act_key = LV_KEY_END;
+                break;
+
+            // Row 3
+            case 0x60: case 0x2F: case 0x5C: case 0x2D: case 0x3D:
+            case 0x5B: case 0x5D: // `/\-=[] Keys
+                act_key = r;
+                break;
+
+            // Row 3 Layer2
+            case 0x7E: act_key = '~'; break;
+            case 0x3F: act_key = '?'; break;
+            case 0x7C: act_key = '|'; break;
+            case 0x5F: act_key = '_'; break;
+            case 0x2B: act_key = '+'; break;
+            case 0x7B: act_key = '{'; break;
+            case 0x7D: act_key = '}'; break;
+
+            // Row 4
+            case 0x30: case 0x31: case 0x32: case 0x33: case 0x34:
+            case 0x35: case 0x36: case 0x37: case 0x38: case 0x39: // 0-9 Keys
+                act_key = r;
+                break;
+
+            // Row 4 Layer2
+            case 0x21: case 0x40: case 0x23: case 0x24: case 0x25:
+            case 0x5E: case 0x26: case 0x2A: case 0x28: case 0x29: // !@#$%^&*() Keys
+                act_key = r;
+                break;
+
+            // Row 5 Layer2
+            case 0xD1: // Insert
+                printf("WARN: Insert key not mapped\n");
+                act_key = 0;
+                break;
+
+            // Row 7 Layer 2
+            case 0x3C: act_key = '<'; break;
+            case 0x3E: act_key = '>'; break;
+
+            // Row 8
+            case 0x3B: case 0x27: case 0x3A: case 0x22: // ;:'"" Keys
+                act_key = r;
+                break;
+            case 0xA5: // CTL
+                printf("WARN: CTL key not mapped\n");
+                act_key = 0;
+                break;
+            case 0x20: // SPACE
+                act_key = r;
+                break;
+            case 0xA1: // ALT
+                printf("WARN: ALT key not mapped\n");
+                act_key = 0;
+                break;
+            case 0xA2: case 0xA3: // RIGHT/LEFT SHIFT
+                break;
+
             default:
                 act_key = r;
                 break;
@@ -133,8 +234,7 @@ static void keypad_read(lv_indev_t * indev_drv, lv_indev_data_t * data)
         data->key = act_key;
         last_key = act_key;
         pending_release = true;
-    }
-    else {
+    } else {
         data->state = LV_INDEV_STATE_RELEASED;
         data->key = 0;
     }

--- a/Code/picocalc_lvgl_graphics_demo/main.c
+++ b/Code/picocalc_lvgl_graphics_demo/main.c
@@ -29,6 +29,16 @@
 
 const unsigned int LEDPIN = 25;
 
+
+
+
+// The event handler
+static void textarea_event_handler(lv_event_t *e) {
+    lv_obj_t *textarea = lv_event_get_target(e);
+    printf("Textarea: '%s'\n", lv_textarea_get_text(textarea));
+}
+
+
 int main()
 {
     // Initialize standard I/O
@@ -56,14 +66,19 @@ int main()
     // Create a screen
     lv_obj_t *screen = lv_obj_create(NULL);
 
-    // Create a text box
-    lv_obj_t *textbox = lv_textarea_create(screen);
-    lv_obj_set_size(textbox, 200, 50); // Set size of the text box
-    lv_obj_align(textbox, LV_ALIGN_CENTER, 0, 0); // Center the text box on the screen
-
+    // The textarea
+    lv_obj_t *input = lv_textarea_create(screen);
+    lv_obj_set_width(input, 320);
+    lv_obj_set_height(input, LV_SIZE_CONTENT);    /// 20
+    lv_obj_set_x(input, -10);
+    lv_obj_set_y(input, 91);
+    lv_obj_set_align(input, LV_ALIGN_CENTER);
     // Enable keyboard input for the text box
-    lv_textarea_set_placeholder_text(textbox, "Enter text...");
-    lv_textarea_set_one_line(textbox, true); // Set to single-line mode
+    lv_textarea_set_placeholder_text(input, "Input:");
+    lv_textarea_set_one_line(input, true);
+    lv_obj_set_style_anim_time(input, 5000, LV_PART_CURSOR|LV_STATE_FOCUSED);
+    // Textarea event handler
+    lv_obj_add_event_cb(input, textarea_event_handler, LV_EVENT_READY, input);
 
     // Load the screen
     lv_scr_load(screen);
@@ -73,7 +88,7 @@ int main()
     while (1)
     {
         lv_timer_handler();
-        lv_tick_inc(5); // Increment LVGL tick by 5 milliseconds
-        sleep_ms(1); // Sleep for 5 milliseconds}
+        lv_tick_inc(20); // Increment LVGL tick by 5 milliseconds
+        sleep_ms(5); // Sleep for 5 milliseconds}
     }
 }

--- a/Code/picocalc_lvgl_graphics_demo/main.c
+++ b/Code/picocalc_lvgl_graphics_demo/main.c
@@ -68,11 +68,9 @@ int main()
 
     // The textarea
     lv_obj_t *input = lv_textarea_create(screen);
-    lv_obj_set_width(input, 320);
+    lv_obj_set_width(input, 280);
     lv_obj_set_height(input, LV_SIZE_CONTENT);    /// 20
-    lv_obj_set_x(input, -10);
-    lv_obj_set_y(input, 91);
-    lv_obj_set_align(input, LV_ALIGN_CENTER);
+    lv_obj_center(input);
     // Enable keyboard input for the text box
     lv_textarea_set_placeholder_text(input, "Input:");
     lv_textarea_set_one_line(input, true);


### PR DESCRIPTION
Fixes #10 issue

## Problem
Keyboard keycode read from I2C keyboard was lousy return to LVGL causing hex input issue. Described in the Issue ticket.
 
## Fixed
- More deterministic case match, case/switch out all the possible I2C keyboard events, mapping to LVGL as much as possible. and remaps others properly. 
- This verbose key case handling also enable user to handle special key event's themselves. 