### PR TITLE
picocalc_keyboard.ino: wait a bit before initializing i2c

### DIFF
--- a/Code/picocalc_keyboard/picocalc_keyboard.ino
+++ b/Code/picocalc_keyboard/picocalc_keyboard.ino
@@ -403,6 +403,8 @@ void setup() {
   pinMode(PA13, OUTPUT);  // pico enable
   digitalWrite(PA13, LOW);
   reg_init();
+
+  delay(10);
   
   Serial1.begin(115200);
 


### PR DESCRIPTION
fixes stm32 not showing up in i2c bus when ds3231 RTC board is added.