### PR TITLE
picocalc_keyboard.ino: don't turn off backlight during register read

### DIFF
--- a/Code/picocalc_keyboard/picocalc_keyboard.ino
+++ b/Code/picocalc_keyboard/picocalc_keyboard.ino
@@ -130,8 +130,10 @@ void receiveEvent(int howMany) {
       write_buffer[1] = (uint8_t)item.key;
     } break;
     case REG_ID_BKL: {
-      reg_set_value(REG_ID_BKL, rcv_data[1]);
-      lcd_backlight_update_reg();
+      if (is_write) {
+        reg_set_value(REG_ID_BKL, rcv_data[1]);
+        lcd_backlight_update_reg();
+      }
       write_buffer[0] = reg;
       write_buffer[1] = reg_get_value(REG_ID_BKL);
     } break;


### PR DESCRIPTION
somebody forgot to use is_write

fixes blacked out screen when backlight register is read.