### PR TITLE
Allow setting keyboard backlight via i2c

### DIFF
--- a/Code/picocalc_keyboard/picocalc_keyboard.ino
+++ b/Code/picocalc_keyboard/picocalc_keyboard.ino
@@ -137,6 +137,17 @@ void receiveEvent(int howMany) {
       write_buffer[0] = reg;
       write_buffer[1] = reg_get_value(REG_ID_BKL);
     } break;
+    case REG_ID_BK2: {
+      if (is_write) {
+        reg_set_value(REG_ID_BK2, rcv_data[1]);
+        // kbd_backlight_update will add 0 to the reg
+        // value that we just set, and apply the result
+        // to the backlight
+        kbd_backlight_update(0);
+      }
+      write_buffer[0] = reg;
+      write_buffer[1] = reg_get_value(REG_ID_BK2);
+    } break;
     case REG_ID_BAT:{
       //Serial1.print("REG_ID_BAT getBatteryPercent:");Serial1.print(current_bat_pcnt);Serial1.println("%");
       write_buffer[0] = reg;


### PR DESCRIPTION
This hooks up the write portion of REG_ID_BK2

closes: https://github.com/clockworkpi/PicoCalc/issues/13