### PR TITLE
sd_boot: add bootmode mechanism

### DIFF
--- a/Code/pico_multi_booter/sd_boot/CMakeLists.txt
+++ b/Code/pico_multi_booter/sd_boot/CMakeLists.txt
@@ -40,9 +40,10 @@ target_compile_options(${APP_NAME} PRIVATE
         -Wall
         -Wno-unused-variable
         -Wno-unused-function
+        -DPICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE=0
 ) 
 
-pico_enable_stdio_usb(${APP_NAME} 0)
+pico_enable_stdio_usb(${APP_NAME} 1)
 pico_enable_stdio_uart(${APP_NAME} 1)
 
 pico_add_extra_outputs(${APP_NAME})

--- a/Code/pico_multi_booter/sd_boot/i2ckbd/i2ckbd.c
+++ b/Code/pico_multi_booter/sd_boot/i2ckbd/i2ckbd.c
@@ -83,3 +83,25 @@ int read_battery() {
     }
     return -1;
 }
+
+int read_bootmode() {
+    int retval;
+    unsigned char msg[2];
+    msg[0] = 0x0e; // REG_ID_BOOT
+
+    if (i2c_inited == 0) return -1;
+
+    retval = i2c_write_timeout_us(I2C_KBD_MOD, I2C_KBD_ADDR, msg, 1, false, 500000);
+    if (retval == PICO_ERROR_GENERIC || retval == PICO_ERROR_TIMEOUT) {
+        DEBUG_PRINT("Boot I2C write err\n");
+        return -1;
+    }
+    sleep_ms(16);
+    retval = i2c_read_timeout_us(I2C_KBD_MOD, I2C_KBD_ADDR, (unsigned char *) msg, 2, false, 500000);
+    if (retval == PICO_ERROR_GENERIC || retval == PICO_ERROR_TIMEOUT || msg[0] != 0x0e) {
+        DEBUG_PRINT("Boot I2C read err\n");
+        return -1;
+    }
+
+    return msg[1];
+}

--- a/Code/pico_multi_booter/sd_boot/i2ckbd/i2ckbd.h
+++ b/Code/pico_multi_booter/sd_boot/i2ckbd/i2ckbd.h
@@ -16,6 +16,7 @@
 void init_i2c_kbd();
 int read_i2c_kbd();
 int read_battery();
+int read_bootmode();
 
 #define bitRead(value, bit) (((value) >> (bit)) & 0x01)
 #define bitClear(value, bit) ((value) &= ~(1 << (bit)))

--- a/Code/pico_multi_booter/sd_boot/main.c
+++ b/Code/pico_multi_booter/sd_boot/main.c
@@ -15,6 +15,8 @@
 #include <stdio.h>
 #include <string.h>
 #include "pico/stdlib.h"
+#include "pico/bootrom.h"
+#include "pico/usb_reset_interface.h"
 #include "hardware/gpio.h"
 #include "hardware/clocks.h"
 #include "debug.h"
@@ -202,6 +204,35 @@ static bool is_valid_application(uint32_t *app_location)
     return true;
 }
 
+void boot_default()
+{
+    DEBUG_PRINT("entering boot_default\n");
+    // Get the pointer to the application flash area
+    uint32_t *app_location = (uint32_t *)(XIP_BASE + SD_BOOT_FLASH_OFFSET);
+    launch_application_from(app_location);
+    // We should never reach here
+    while (1)
+    {
+        tight_loop_contents();
+    }
+}
+
+void boot_fwupdate()
+{
+    DEBUG_PRINT("entering boot_fwupdate\n");
+    lcd_init();
+    lcd_clear();
+
+    draw_rect_spi(20, 140, 300, 180, WHITE);
+    lcd_set_cursor(30, 150);
+    lcd_print_string_color((char *)"FIRMWARE UPDATE", BLACK, WHITE);
+
+    sleep_ms(2000);
+
+    uint gpio_mask = 0u;
+    reset_usb_boot(gpio_mask, PICO_STDIO_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK);
+}
+
 int load_firmware_by_path(const char *path)
 {
     text_directory_ui_set_status("STAT: Flashing firmware...");
@@ -298,6 +329,27 @@ int main()
     gpio_pull_up(SD_DET_PIN); // Enable pull-up resistor
 
     keypad_init();
+
+    // Check bootmode now: 0=default, 1=sdcard, 2=fwupdate
+    int bootmode = read_bootmode();
+    DEBUG_PRINT("bootmode = %d\n", bootmode);
+    switch(bootmode) {
+      case 0:
+        // BOOTMODE_DEFAULT
+        boot_default();
+        break;
+      case 2:
+        // BOOTMODE_FWUPDATE
+        boot_fwupdate();
+        break;
+      case 1:
+        // BOOTMODE_SDCARD
+      default:
+        break;
+    }
+
+    // BEGIN SDCARD BOOT
+
     lcd_init();
     lcd_clear();
 	text_directory_ui_pre_init();

--- a/Code/picocalc_keyboard/keyboard.h
+++ b/Code/picocalc_keyboard/keyboard.h
@@ -58,6 +58,10 @@ enum key_state
 #define KEY_F9 0x89
 #define KEY_F10 0x90
 
+#define BOOTMODE_DEFAULT  0x00 // normal boot mode
+#define BOOTMODE_SDCARD   0x01 // sdcard multiboot: loads .bin to FLASH+200K
+#define BOOTMODE_FWUPDATE 0x02 // enter BOOTSEL to upload .uf2 firmware
+
 typedef void (*key_callback)(char, enum key_state);
 typedef void (*lock_callback)(bool, bool);
 
@@ -66,6 +70,7 @@ void keyboard_set_key_callback(key_callback callback);
 void keyboard_set_lock_callback(lock_callback callback);
 bool keyboard_get_capslock(void);
 bool keyboard_get_numlock(void);
+uint8_t keyboard_get_bootmode(void);
 void keyboard_init(void);
 
 #define NUM_OF_COLS 8

--- a/Code/picocalc_keyboard/keyboard.ino
+++ b/Code/picocalc_keyboard/keyboard.ino
@@ -78,6 +78,8 @@ static struct {
 
     bool numlock_changed;
     bool numlock;
+
+    uint8_t bootmode;
 } self;
 
 void output_string(char*str){
@@ -423,6 +425,11 @@ bool keyboard_get_numlock(void)
   return self.numlock;
 }
 
+uint8_t keyboard_get_bootmode(void)
+{
+  return self.bootmode;
+}
+
 void keyboard_init(void)
 {
   struct port_config port_init;
@@ -430,6 +437,8 @@ void keyboard_init(void)
 
   for (int i = 0; i < MOD_LAST; ++i)
     self.mods[i] = false;
+
+  self.bootmode = BOOTMODE_DEFAULT;
 
   // Rows
   port_init.direction = PORT_PIN_DIR_INPUT;
@@ -449,5 +458,13 @@ void keyboard_init(void)
   port_init.input_pull = PORT_PIN_PULL_UP;
   for(uint32_t i = 0; i < NUM_OF_BTNS; ++i)
     port_pin_set_config(btn_pins[i], &port_init);
+
+  //B12=left,B11=down [FWUPDATE],B10=up [SDCARD-MULTIBOOT],B9=right
+  if (port_pin_get_input_level(btn_pins[10]) == 0) {
+    self.bootmode = BOOTMODE_FWUPDATE;
+  }
+  if (port_pin_get_input_level(btn_pins[9]) == 0) {
+    self.bootmode = BOOTMODE_SDCARD;
+  }
 #endif
 }

--- a/Code/picocalc_keyboard/picocalc_keyboard.ino
+++ b/Code/picocalc_keyboard/picocalc_keyboard.ino
@@ -168,6 +168,11 @@ void receiveEvent(int howMany) {
       write_buffer[1] = js_bits;
       write_buffer_len = 2;
     }break;
+    case REG_ID_BOOT:{
+      write_buffer[0] = reg;
+      write_buffer[1] = keyboard_get_bootmode();
+      write_buffer_len = 2;
+    }break;
     default: {
       write_buffer[0] = 0;
       write_buffer[1] = 0;

--- a/Code/picocalc_keyboard/reg.h
+++ b/Code/picocalc_keyboard/reg.h
@@ -19,6 +19,7 @@ enum reg_id
   REG_ID_BAT = 0x0b,// battery
   REG_ID_C64_MTX = 0x0c,// read c64 matrix
   REG_ID_C64_JS = 0x0d, // joystick io bits
+  REG_ID_BOOT = 0x0e, // boot mode (see keyboard.h)
   REG_ID_LAST,
 };
 

--- a/Code/picocalc_keyboard/reg.ino
+++ b/Code/picocalc_keyboard/reg.ino
@@ -1,4 +1,5 @@
 #include "reg.h"
+#include "keyboard.h"
 
 static uint8_t regs[REG_ID_LAST];
 
@@ -42,4 +43,5 @@ void reg_init(void)
   regs[REG_ID_BKL] = 255;//100%duty
   regs[REG_ID_BK2] = 0;
   regs[REG_ID_BAT] = 0; //default .no battery ,no charging
+  regs[REG_ID_BOOT] = BOOTMODE_DEFAULT;
 }


### PR DESCRIPTION
This PR modifies the sd_boot multi booter so that:

- Hold UP and power on: boot into SD app booter
- Hold DOWN and power on: boot into BOOTSEL
- Just power on: silently boot into flashed program

This will make the behavior closer to default boot, where PicoCalc can be a boot-to-app gadget, while retaining the option to SDCARD-boot or BOOTSEL-boot (without clicking the reset button).