### PR TITLE
Modify stack pointer validation range to allow scratch banks

### DIFF
--- a/Code/pico_multi_booter/sd_boot/main.c
+++ b/Code/pico_multi_booter/sd_boot/main.c
@@ -190,7 +190,8 @@ static bool is_valid_application(uint32_t *app_location)
 {
     // Check that the initial stack pointer is within a plausible RAM region (assumed range for Pico: 0x20000000 to 0x20040000)
     uint32_t stack_pointer = app_location[0];
-    if (stack_pointer < 0x20000000 || stack_pointer > MAX_RAM)
+	
+    if (stack_pointer < 0x20000000 || stack_pointer > MAX_RAM + 2*4*1024) // MAX_RAM + 8KB
     {
         return false;
     }


### PR DESCRIPTION
When making a bootloader on the RP2040, I implemented this code. However my test app had its stack pointer outside the valid RAM region and in the scratch_x/scratch_y area of memory. Seeing as allowing the stack pointer to be in this area made my test program work flawlessly I suggest this to be implemented to the repository.