### PR TITLE
Fix pointer handling for fp in sd_boot

### DIFF
--- a/Code/pico_multi_booter/sd_boot/main.c
+++ b/Code/pico_multi_booter/sd_boot/main.c
@@ -171,6 +171,9 @@ static bool __not_in_flash_func(load_program)(const char *filename)
         fclose(fp);
         return true;
     }
+	// We need to set the pointer back because is_same_existing_program will move the file pointer (fp)
+	// whether we like it or not.
+	fseek(fp, 0, SEEK_SET);
 	
     size_t program_size = 0;
     uint8_t buffer[FLASH_SECTOR_SIZE] = {0};


### PR DESCRIPTION
The is_same_existing_program (I renamed it to "is_same_**as**_existing_program because grammar) was moving the file pointer arbitrarily, without the load_program function accounting for this behaviour. I simply reset the pointer back after the check.

I apologize for not correcting this sooner, this might have caused a lot of issues for those who cloned the repository within the last months. 