### PR TITLE
Fixed previous PR and changed load/launch logic

### DIFF
--- a/Code/pico_multi_booter/sd_boot/main.c
+++ b/Code/pico_multi_booter/sd_boot/main.c
@@ -43,7 +43,8 @@ const uint LEDPIN = 25;
 #define VTOR_OFFSET M33_VTOR_OFFSET
 #define MAX_RAM 0x20080000
 #endif
-uint8_t status_flag;//0 no sdcard ,1 has sd card
+uint8_t status_flag; //0 no sdcard , 1 has sd card
+
 bool sd_card_inserted(void)
 {
     status_flag = !gpio_get(SD_DET_PIN);
@@ -88,10 +89,12 @@ bool fs_init(void)
 
 static bool __not_in_flash_func(is_same_existing_program)(FILE *fp)
 {
+	// Save the file pointer so that the original isn't affected by fread()
+	FILE *fp_separate = fp;
     uint8_t buffer[FLASH_SECTOR_SIZE] = {0};
     size_t program_size = 0;
     size_t len = 0;
-    while ((len = fread(buffer, 1, sizeof(buffer), fp)) > 0)
+    while ((len = fread(buffer, 1, sizeof(buffer), fp_separate)) > 0)
     {
         uint8_t *flash = (uint8_t *)(XIP_BASE + SD_BOOT_FLASH_OFFSET + program_size);
         if (memcmp(buffer, flash, len) != 0)
@@ -171,9 +174,6 @@ static bool __not_in_flash_func(load_program)(const char *filename)
         fclose(fp);
         return true;
     }
-	// We need to set the pointer back because is_same_existing_program will move the file pointer (fp)
-	// whether we like it or not.
-	fseek(fp, 0, SEEK_SET);
 	
     size_t program_size = 0;
     uint8_t buffer[FLASH_SECTOR_SIZE] = {0};
@@ -260,13 +260,16 @@ int load_firmware_by_path(const char *path)
     // Check if there is an already valid application in flash
     bool has_valid_app = is_valid_application(app_location);
 
-    if(path == NULL) {
+	// When path is null, we only wish to launch, not load, so we need to check the validity as well.
+    if(path == NULL && has_valid_app) {
         load_success = true;
     }else{
         load_success = load_program(path);
+		has_valid_app = is_valid_application(app_location);
     }
 
-    if (load_success || has_valid_app)
+	// Both conditions should be met when launching
+    if (load_success && has_valid_app)
     {
         text_directory_ui_set_status("STAT: Launching app...");
         DEBUG_PRINT("launching app\n");

--- a/Code/pico_multi_booter/sd_boot/main.c
+++ b/Code/pico_multi_booter/sd_boot/main.c
@@ -43,7 +43,7 @@ const uint LEDPIN = 25;
 #define VTOR_OFFSET M33_VTOR_OFFSET
 #define MAX_RAM 0x20080000
 #endif
-uint8_t status_flag; //0 no sdcard , 1 has sd card
+uint8_t status_flag; // 0 no sdcard , 1 has sd card
 
 bool sd_card_inserted(void)
 {
@@ -87,7 +87,7 @@ bool fs_init(void)
     return true;
 }
 
-static bool __not_in_flash_func(is_same_existing_program)(FILE *fp)
+static bool __not_in_flash_func(is_same_as_existing_program)(FILE *fp)
 {
 	// Save the file pointer so that the original isn't affected by fread()
 	FILE *fp_separate = fp;
@@ -168,7 +168,7 @@ static bool __not_in_flash_func(load_program)(const char *filename)
     }
 
 	// Only check for validity after the guard clauses to make sure the file pointer (fp) is valid
-    if ( is_same_existing_program(fp) && is_valid_application((uint32_t*)(XIP_BASE + SD_BOOT_FLASH_OFFSET)) )
+    if ( is_same_as_existing_program(fp) && is_valid_application((uint32_t*)(XIP_BASE + SD_BOOT_FLASH_OFFSET)) )
     {
         DEBUG_PRINT("Same program already valid in flash, skipping\n");
         fclose(fp);
@@ -224,7 +224,9 @@ void boot_default()
     // Get the pointer to the application flash area
     uint32_t *app_location = (uint32_t *)(XIP_BASE + SD_BOOT_FLASH_OFFSET);
     launch_application_from(app_location);
+	
     // We should never reach here
+	DEBUG_PRINT("err: booting default application, launching program failed\n");
     while (1)
     {
         tight_loop_contents();

--- a/Code/pico_multi_booter/sd_boot/main.c
+++ b/Code/pico_multi_booter/sd_boot/main.c
@@ -265,7 +265,11 @@ int load_firmware_by_path(const char *path)
 	// When path is null, we only wish to launch, not load, so we need to check the validity as well.
     if(path == NULL && has_valid_app) {
         load_success = true;
-    }else{
+    }else if(path == NULL && !has_valid_app) {
+		DEBUG_PRINT("err: given path is NULL but existing program is invalid, rebooting\n");
+		sleep_ms(2000);
+        watchdog_reboot(0, 0, 0);
+	}else{ // Independent of validity, a path indicates that we wish to load it.
         load_success = load_program(path);
 		has_valid_app = is_valid_application(app_location);
     }


### PR DESCRIPTION
I revised my previous PR, the `is_same_existing` function - which is renamed, again, because my previous PR didn't change it for some reason - now handles the file pointer independently of the given file. Meaning it does not change the file pointer when checking via `is_same_as_existing_program` in `load_program`, so we can remove the fseek call.

I also changed the conditions needed to launch a program in `load_firmware_by_path`. Previously, having a NULL path would launch the program with zero regard for how valid the pointers in flash are. Now, `load_success` and `has_valid_app` both need to be true for the app to load.

This also means that, naturally, when `path` is null and the program in flash is valid, we say `load_success` is true, even though there was no load. Likewise, when we load a new program, the validity has to be checked again.
